### PR TITLE
Fix ES6 module style

### DIFF
--- a/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.js
+++ b/packages/bruno-app/src/components/Sidebar/Collections/Collection/CollectionItem/GenerateCodeItem/utils/snippet-generator.js
@@ -1,8 +1,8 @@
-const { buildHarRequest } = require('utils/codegenerator/har');
-const { getAuthHeaders } = require('utils/codegenerator/auth');
-const { getAllVariables } = require('utils/collections/index');
-const { interpolateHeaders, interpolateBody, createVariablesObject } = require('./interpolation');
-const { resolveInheritedAuth } = require('./auth-utils');
+import { buildHarRequest } from 'utils/codegenerator/har';
+import { getAuthHeaders } from 'utils/codegenerator/auth';
+import { getAllVariables } from 'utils/collections/index';
+import { interpolateHeaders, interpolateBody, createVariablesObject } from './interpolation';
+import { resolveInheritedAuth } from './auth-utils';
 
 const generateSnippet = ({ language, item, collection, shouldInterpolate = false }) => {
   try {
@@ -58,6 +58,6 @@ const generateSnippet = ({ language, item, collection, shouldInterpolate = false
   }
 };
 
-module.exports = {
+export {
   generateSnippet
 }; 


### PR DESCRIPTION
# Description

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Contribution Checklist:

- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [ ] **Create an issue and link to the pull request.**

This pull request refactors the `snippet-generator.js` file to use ES6 module syntax for imports and exports instead of CommonJS. This change modernizes the codebase and aligns it with current JavaScript standards.

### Refactoring to ES6 module syntax:

* Replaced CommonJS `require` statements with ES6 `import` statements for all dependencies in `snippet-generator.js`.
* Changed the export from `module.exports` to an ES6 `export` statement for the `generateSnippet` function.